### PR TITLE
Send pubacks manually

### DIFF
--- a/MQTTClient/MQTTClient/MQTTSession.h
+++ b/MQTTClient/MQTTClient/MQTTSession.h
@@ -604,7 +604,8 @@ typedef void (^MQTTPublishHandler)(NSError *error);
  
  */
 
-- (UInt16)subscribeToTopic:(NSString *)topic atLevel:(MQTTQosLevel)qosLevel subscribeHandler:(MQTTSubscribeHandler)subscribeHandler explicitAcks:(BOOL)explicitAcks;
+- (UInt16)subscribeToTopic:(NSString *)topic atLevel:(MQTTQosLevel)qosLevel subscribeHandler:(MQTTSubscribeHandler)subscribeHandler;
+
 
 /** subscribes to a topic at a specific QoS level
  
@@ -624,7 +625,8 @@ typedef void (^MQTTPublishHandler)(NSError *error);
  
  */
 
-- (UInt16)subscribeToTopic:(NSString *)topic atLevel:(MQTTQosLevel)qosLevel subscribeHandler:(MQTTSubscribeHandler)subscribeHandler;
+- (UInt16)subscribeToTopic:(NSString *)topic atLevel:(MQTTQosLevel)qosLevel subscribeHandler:(MQTTSubscribeHandler)subscribeHandler explicitAcks:(BOOL)explicitAcks;
+
 
 /** subscribes a number of topics
  

--- a/MQTTClient/MQTTClient/MQTTSession.h
+++ b/MQTTClient/MQTTClient/MQTTSession.h
@@ -604,6 +604,26 @@ typedef void (^MQTTPublishHandler)(NSError *error);
  
  */
 
+- (UInt16)subscribeToTopic:(NSString *)topic atLevel:(MQTTQosLevel)qosLevel subscribeHandler:(MQTTSubscribeHandler)subscribeHandler explicitAcks:(BOOL)explicitAcks;
+
+/** subscribes to a topic at a specific QoS level
+ 
+ @param topic the Topic Filter to subscribe to.
+ 
+ @param qosLevel specifies the QoS Level of the subscription.
+ qosLevel can be 0, 1, or 2.
+ @param subscribeHandler identifies a block which is executed on successfull or unsuccessfull subscription.
+ Might be nil. error is nil in the case of a successful subscription. In this case gQoss represents an
+ array of grantes Qos
+
+ @param explicitAcks If set to YES, messages will not be ACKed automatically. To acknowledge a message, call sendAckWithMessageId:
+ 
+ @return the Message Identifier of the SUBSCRIBE message.
+ 
+ @note returns immediately. To check results, register as an MQTTSessionDelegate and watch for events.
+ 
+ */
+
 - (UInt16)subscribeToTopic:(NSString *)topic atLevel:(MQTTQosLevel)qosLevel subscribeHandler:(MQTTSubscribeHandler)subscribeHandler;
 
 /** subscribes a number of topics
@@ -849,6 +869,16 @@ typedef void (^MQTTPublishHandler)(NSError *error);
  @endcode
  
  */
+
+
+/**
+ Sends an ACK message. Use this only to acknowledge messages received on a topic with the explicitAcks set to YES.
+ 
+ @param mid Message id
+ 
+ */
+- (void)sendAckForMessageId:(unsigned int)mid;
+
 - (void)closeWithDisconnectHandler:(MQTTDisconnectHandler)disconnectHandler;
 
 /** close V5


### PR DESCRIPTION
PUBACKs can be sent explicitly.

Common use case is, app needs to process messages in batches and PUBACKs need to be sent when sure that the app has persisted any new state that results from processing the mqtt messages. Make sure though that the amount of messages not acked doesn't get close to or larger than the amount of messages the MQTT broker can keep in its queue.